### PR TITLE
Add DisplayNetworkReliability job

### DIFF
--- a/src/main/resources/job-scheduler-config.json
+++ b/src/main/resources/job-scheduler-config.json
@@ -99,6 +99,10 @@
     {
       "destinationTableId": "ViewerCrashDisplayCount",
       "fileName": "queries/viewer-display-crash.sql"
+    },
+    {
+      "destinationTableId": "DisplayNetworkReliability",
+      "fileName": "queries/display-network-reliability.sql"
     }
   ]
 }

--- a/src/main/resources/queries/display-network-reliability.sql
+++ b/src/main/resources/queries/display-network-reliability.sql
@@ -1,0 +1,1 @@
+SELECT * FROM [client-side-events:Installer_Events.NetworkReliability]


### PR DESCRIPTION
@settinghead @rodrigopavezi @stulees this is the 24hr refresh job for the network reliability table.  It shows how many displays start without network and how many have network issues during play.  Please review.