### PR TITLE
change query to standard SQL

### DIFF
--- a/src/main/resources/queries/player-module-stats.sql
+++ b/src/main/resources/queries/player-module-stats.sql
@@ -1,1 +1,3 @@
-SELECT * FROM [client-side-events:Installer_Events.PlayerModuleStats]
+#standardSQL
+
+SELECT * FROM `client-side-events.Installer_Events.PlayerModuleStats`


### PR DESCRIPTION
The invoker query should be standard SQL as the referenced view is in standard SQL. According to the logs, this is why the query didn't complete last time.