### PR TITLE
Add missing fields from image_events table inserter

### DIFF
--- a/src/main/resources/table-inserter-config.json
+++ b/src/main/resources/table-inserter-config.json
@@ -256,6 +256,21 @@
           "name": "ts",
           "type": "TIMESTAMP",
           "nullable": false
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "nullable": true
+        },
+        {
+          "name": "local_url",
+          "type": "string",
+          "nullable": true
+        },
+        {
+          "name": "configuration",
+          "type": "string",
+          "nullable": true
         }
       ]
     },


### PR DESCRIPTION
@santiagonoguez There always seems to be a `image_events` table getting created almost 2 days in advance with no row entries. This table is always missing the fields I've added here. This is why I was having issues with my BQ queries last Friday as the real table giving issue was the one ahead of schedule. Hoping this resolves it. 