### PR TITLE
schedule daily displays using HTML templates

### DIFF
--- a/src/main/resources/job-scheduler-config.json
+++ b/src/main/resources/job-scheduler-config.json
@@ -187,6 +187,10 @@
     {
       "destinationTableId": "ClientSideApplicationsTableStats",
       "fileName": "queries/client-side-applications-table-stats.sql"
+    },
+    {
+      "destinationTableId": "DisplaysUsingHtmlTemplates",
+      "fileName": "queries/displays-using-html-templates.sql"
     }
   ]
 }

--- a/src/main/resources/queries/displays-using-html-templates.sql
+++ b/src/main/resources/queries/displays-using-html-templates.sql
@@ -1,0 +1,3 @@
+#StandardSQL
+
+SELECT * FROM `client-side-events.Display_Events.DisplaysUsingHtmlTemplates`


### PR DESCRIPTION
This schedules the query for the aggregate table for template usage. The scheduling will need no further adjustment when in the future we change from product code to template name.
