### PR TITLE
schedule k12 companies using recommended templates query

### DIFF
--- a/src/main/resources/job-scheduler-config.json
+++ b/src/main/resources/job-scheduler-config.json
@@ -69,6 +69,14 @@
     {
       "destinationTableId": "MultipleUnreliableV3StartsPlayerCount",
       "fileName": "queries/multiple-unreliable-v3-starts-player-count.sql"
+    },
+    {
+      "destinationTableId": "K12DisplaysUsingTemplatesStats",
+      "fileName": "queries/k12-displays-using-templates-stats.sql"
+    },
+    {
+      "destinationTableId": "K12CompaniesUsingTemplatesStats",
+      "fileName": "queries/k12-companies-using-templates-stats.sql"
     }
   ],
   "every24Hours": [
@@ -177,20 +185,16 @@
       "fileName": "queries/component-errors-and-warnings.sql"
     },
     {
-      "destinationTableId": "K12DisplaysUsingTemplatesStats",
-      "fileName": "queries/k12-displays-using-templates-stats.sql"
-    },
-    {
-      "destinationTableId": "K12CompaniesUsingTemplatesStats",
-      "fileName": "queries/k12-companies-using-templates-stats.sql"
-    },
-    {
       "destinationTableId": "ClientSideApplicationsTableStats",
       "fileName": "queries/client-side-applications-table-stats.sql"
     },
     {
       "destinationTableId": "DisplaysUsingHtmlTemplates",
       "fileName": "queries/displays-using-html-templates.sql"
+    },
+    {
+      "destinationTableId": "K12CompaniesUsingRecommendedTemplates",
+      "fileName": "queries/k12-companies-using-recommended-templates.sql"
     }
   ]
 }

--- a/src/main/resources/queries/k12-companies-using-recommended-templates.sql
+++ b/src/main/resources/queries/k12-companies-using-recommended-templates.sql
@@ -1,0 +1,3 @@
+#StandardSQL
+
+SELECT * FROM `client-side-events.Display_Events.K12CompaniesUsingRecommendedTemplates`


### PR DESCRIPTION
1.- Added K12 companies using recommended templates query and schedule.

2.- Moved K12 displays and companies using templates to each 4 hours. As these queries now depend on another aggregate table that is also being generated here, and apparently the queries run asynchronously, the order or execution and completion is not guaranteed. By executing these more than once, we can guarantee that the second run will work with the aggregate table already filled. A cleaner approach may be to modify the project code to solve this without too many repeats, and we can discuss later creating a future design and card for this.