### PR TITLE
add google drive read-only scope

### DIFF
--- a/src/main/java/com/risevision/bigquery/BigqueryCommonApi.java
+++ b/src/main/java/com/risevision/bigquery/BigqueryCommonApi.java
@@ -13,6 +13,8 @@ import java.util.logging.Logger;
 public class BigqueryCommonApi {
   private GoogleCredential credential;
   protected Bigquery bqClient;
+
+  private static final String SHEETS_SCOPE = "https://www.googleapis.com/auth/drive.readonly";
   private static final Logger log = Logger.getAnonymousLogger();
 
    public BigqueryCommonApi(HttpTransport transport) {
@@ -27,7 +29,7 @@ public class BigqueryCommonApi {
       return;
     }
 
-    credential = credential.createScoped(Arrays.asList(BigqueryScopes.BIGQUERY));
+    credential = credential.createScoped(Arrays.asList(BigqueryScopes.BIGQUERY, SHEETS_SCOPE));
 
     bqClient = new Bigquery.Builder
     (transport, JacksonFactory.getDefaultInstance(), credential)


### PR DESCRIPTION
This adds a scope to the BQ authentication, so queries can read from Google spreadsheets. The following query:

https://github.com/Rise-Vision/client-side-events/blob/master/src/main/resources/queries/k12-companies-using-recommended-templates.sql

is currently failing with the error:

Access Denied: BigQuery BigQuery: No OAuth token with Google Drive scope was found.

I tested locally that adding the scope works using a code with the same libraries of client-side-events. 

The test I used is based on code from: https://github.com/Rise-Vision/client-side-events/blob/master/src/main/java/com/risevision/bigquery/BigqueryCommonApi.java

The complete test class follows:

```
package bq;

import java.util.Arrays;

import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
import com.google.api.client.http.HttpTransport;
import com.google.api.client.http.javanet.NetHttpTransport;
import com.google.api.client.json.jackson2.JacksonFactory;
import com.google.api.services.bigquery.Bigquery;
import com.google.api.services.bigquery.BigqueryScopes;
import com.google.api.services.bigquery.model.Job;
import com.google.api.services.bigquery.model.JobConfiguration;
import com.google.api.services.bigquery.model.JobConfigurationQuery;
import com.google.api.services.bigquery.model.JobReference;
import com.google.api.services.bigquery.model.TableReference;

public class BqTest
{

  private static final String SHEETS_SCOPE = "https://www.googleapis.com/auth/drive.readonly";

  public static void main(String[] args) throws Exception
  {
    GoogleCredential credential = GoogleCredential.getApplicationDefault();
    credential = credential.createScoped(Arrays.asList(BigqueryScopes.BIGQUERY, SHEETS_SCOPE));

    HttpTransport transport = new NetHttpTransport();
    JacksonFactory jacksonFactory = JacksonFactory.getDefaultInstance();

    Bigquery bigQuery = new Bigquery.Builder( transport, jacksonFactory, credential ).build();

    Job job = getJob();

    bigQuery.jobs().insert("client-side-events", job).execute();
  }

  private static Job getJob()
  {
    Job job = new Job();
    JobConfiguration jobConfiguration = new JobConfiguration();
    JobConfigurationQuery jobConfigurationQuery = new JobConfigurationQuery();
    JobReference jobReference = new JobReference();
    String sqlQuery =
      "#StandardSQL\n\nSELECT template FROM `client-side-events.Display_Events.RecommendedTemplates`";
    TableReference destinationTable = new TableReference();

    // Prepare BigQuery request objects
    job.setJobReference(jobReference);
    job.setConfiguration(jobConfiguration);
    jobConfiguration.setQuery(jobConfigurationQuery);
    jobConfigurationQuery.setDestinationTable(destinationTable);

    // Configuration common to all jobs
    jobReference.setProjectId("client-side-events");
    jobConfigurationQuery.setWriteDisposition("WRITE_TRUNCATE");
    destinationTable.setProjectId("client-side-events");
    destinationTable.setDatasetId("Display_Events");

    // Job-specific configuration
    jobConfigurationQuery.setQuery(sqlQuery);
    destinationTable.setTableId("Test_Output");

    return job;
  }

}
```
POM file:

```xml
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.test</groupId>
  <artifactId>bq</artifactId>
  <version>0.0.1-SNAPSHOT</version>
  
  <properties>
    <appengine.sdk.version>1.9.63</appengine.sdk.version>
  </properties>

  <dependencies>
    <dependency>
      <groupId>com.google.appengine</groupId>
      <artifactId>appengine-api-1.0-sdk</artifactId>
      <version>${appengine.sdk.version}</version>
    </dependency>
    <dependency>
      <groupId>com.google.code.gson</groupId>
      <artifactId>gson</artifactId>
      <version>2.3.1</version>
    </dependency>
    <dependency>
      <groupId>com.google.api-client</groupId>
      <artifactId>google-api-client-appengine</artifactId>
      <version>1.23.0</version>
    </dependency>
    <dependency>
      <groupId>com.google.apis</groupId>
      <artifactId>google-api-services-bigquery</artifactId>
      <version>v2-rev377-1.23.0</version>
    </dependency>
    <dependency>
      <groupId>com.google.api-client</groupId>
      <artifactId>google-api-client-jackson2</artifactId>
      <version>1.23.0</version>
    </dependency>
    <dependency>
      <groupId>com.google.appengine</groupId>
      <artifactId>appengine-testing</artifactId>
      <version>${appengine.sdk.version}</version>
      <scope>test</scope>
    </dependency>
    <dependency>
      <groupId>com.google.appengine</groupId>
      <artifactId>appengine-api-stubs</artifactId>
      <version>${appengine.sdk.version}</version>
      <scope>test</scope>
    </dependency>
  </dependencies>
</project>
```
