### PR TITLE
Explicitly declare legacy SQL dialect

### DIFF
--- a/src/main/resources/queries/cache-v2-daily-reliability.sql
+++ b/src/main/resources/queries/cache-v2-daily-reliability.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Rise_Cache_V2.CacheV2DailyReliability]

--- a/src/main/resources/queries/calendar-stats.sql
+++ b/src/main/resources/queries/calendar-stats.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Widget_Events.CalendarStats`

--- a/src/main/resources/queries/client-side-applications-table-stats.sql
+++ b/src/main/resources/queries/client-side-applications-table-stats.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Display_Events.ClientSideApplicationsTableStats`

--- a/src/main/resources/queries/component-errors-and-warnings.sql
+++ b/src/main/resources/queries/component-errors-and-warnings.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Display_Events.ComponentErrorsAndWarnings`

--- a/src/main/resources/queries/component-stats.sql
+++ b/src/main/resources/queries/component-stats.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Display_Events.ComponentStats`

--- a/src/main/resources/queries/content-displays-with-update.sql
+++ b/src/main/resources/queries/content-displays-with-update.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Module_Events.content_displays_with_update`

--- a/src/main/resources/queries/content-update-frequency.sql
+++ b/src/main/resources/queries/content-update-frequency.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Module_Events.content_update_frequency`

--- a/src/main/resources/queries/daily-monthly-active-company-ratio.sql
+++ b/src/main/resources/queries/daily-monthly-active-company-ratio.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Module_Events.daily_monthly_active_company_ratio`

--- a/src/main/resources/queries/display-costs.sql
+++ b/src/main/resources/queries/display-costs.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [rvaserver2:appengine_logs.DisplayCosts]

--- a/src/main/resources/queries/display-count-by-installer-type.sql
+++ b/src/main/resources/queries/display-count-by-installer-type.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Installer_Events.DisplayCountByInstallerType]

--- a/src/main/resources/queries/display-network-reliability.sql
+++ b/src/main/resources/queries/display-network-reliability.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Installer_Events.NetworkReliability]

--- a/src/main/resources/queries/displays-using-html-templates.sql
+++ b/src/main/resources/queries/displays-using-html-templates.sql
@@ -1,3 +1,2 @@
-#StandardSQL
-
+#standardSQL
 SELECT * FROM `client-side-events.Display_Events.DisplaysUsingHtmlTemplates`

--- a/src/main/resources/queries/image-daily-reliability.sql
+++ b/src/main/resources/queries/image-daily-reliability.sql
@@ -1,1 +1,0 @@
-SELECT * FROM [client-side-events:Widget_Events.ImageDailyReliability]

--- a/src/main/resources/queries/image-folder-rls-stats.sql
+++ b/src/main/resources/queries/image-folder-rls-stats.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Widget_Events.ImageFolderRLSStats`

--- a/src/main/resources/queries/image-non-rls-stats.sql
+++ b/src/main/resources/queries/image-non-rls-stats.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Widget_Events.ImageNonRLSStats`

--- a/src/main/resources/queries/image-rls-stats.sql
+++ b/src/main/resources/queries/image-rls-stats.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Widget_Events.ImageRLSStats`

--- a/src/main/resources/queries/image-widget-usage-by-month.sql
+++ b/src/main/resources/queries/image-widget-usage-by-month.sql
@@ -1,1 +1,0 @@
-SELECT * FROM [client-side-events:Widget_Events.ImageUsageMonthly]

--- a/src/main/resources/queries/k12-companies-using-recommended-templates.sql
+++ b/src/main/resources/queries/k12-companies-using-recommended-templates.sql
@@ -1,3 +1,2 @@
-#StandardSQL
-
+#standardSQL
 SELECT * FROM `client-side-events.Display_Events.K12CompaniesUsingRecommendedTemplates`

--- a/src/main/resources/queries/k12-companies-using-templates-stats.sql
+++ b/src/main/resources/queries/k12-companies-using-templates-stats.sql
@@ -1,3 +1,2 @@
-#StandardSQL
-
+#standardSQL
 SELECT * FROM `client-side-events.Widget_Events.K12CompaniesUsingTemplatesStats`

--- a/src/main/resources/queries/k12-displays-using-templates-stats.sql
+++ b/src/main/resources/queries/k12-displays-using-templates-stats.sql
@@ -1,3 +1,2 @@
-#StandardSQL
-
+#standardSQL
 SELECT * FROM `client-side-events.Widget_Events.K12DisplaysUsingTemplatesStats`

--- a/src/main/resources/queries/module-upgrade-stats.sql
+++ b/src/main/resources/queries/module-upgrade-stats.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Installer_Events.ModuleUpgradeStats]

--- a/src/main/resources/queries/multiple-unreliable-v3-starts-player-count.sql
+++ b/src/main/resources/queries/multiple-unreliable-v3-starts-player-count.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Native_Events.MultipleUnreliableV3StartsPlayerCount]

--- a/src/main/resources/queries/new-installation-stats.sql
+++ b/src/main/resources/queries/new-installation-stats.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Installer_Events.NewInstallationStats]

--- a/src/main/resources/queries/player-count-columns-by-os-category.sql
+++ b/src/main/resources/queries/player-count-columns-by-os-category.sql
@@ -1,1 +1,2 @@
-SELECT * FROM [client-side-events:Installer_Events.PlayerCountColumnsByOSCategory]
+#standardSql
+SELECT * FROM `client-side-events.Installer_Events.PlayerCountColumnsByOSCategory`

--- a/src/main/resources/queries/player-module-stats.sql
+++ b/src/main/resources/queries/player-module-stats.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Installer_Events.PlayerModuleStats`

--- a/src/main/resources/queries/player-reliability-stats.sql
+++ b/src/main/resources/queries/player-reliability-stats.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Native_Events.PlayerReliabilityStats]

--- a/src/main/resources/queries/rss-daily-reliability.sql
+++ b/src/main/resources/queries/rss-daily-reliability.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Widget_Events.RssDailyReliability`

--- a/src/main/resources/queries/rss-widget-usage-by-month.sql
+++ b/src/main/resources/queries/rss-widget-usage-by-month.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Widget_Events.RssUsageMonthly]

--- a/src/main/resources/queries/spreadsheet-daily-reliability.sql
+++ b/src/main/resources/queries/spreadsheet-daily-reliability.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Widget_Events.SpreadsheetDailyReliability`

--- a/src/main/resources/queries/text-daily-reliability.sql
+++ b/src/main/resources/queries/text-daily-reliability.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Widget_Events.TextDailyReliability`

--- a/src/main/resources/queries/text-widget-usage-by-month.sql
+++ b/src/main/resources/queries/text-widget-usage-by-month.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Widget_Events.TextUsageMonthly]

--- a/src/main/resources/queries/ticker-daily-reliability.sql
+++ b/src/main/resources/queries/ticker-daily-reliability.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Aggregate_Tables.TickerDailyReliabilityView]

--- a/src/main/resources/queries/time-date-widget-usage-by-month.sql
+++ b/src/main/resources/queries/time-date-widget-usage-by-month.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Widget_Events.TimeDateUsageMonthly]

--- a/src/main/resources/queries/twitter-component-usage-by-month.sql
+++ b/src/main/resources/queries/twitter-component-usage-by-month.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Component_Events.TwitterUsageByMonth]

--- a/src/main/resources/queries/upgrade-stats.sql
+++ b/src/main/resources/queries/upgrade-stats.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Installer_Events.UpgradeStats]

--- a/src/main/resources/queries/video-daily-reliability.sql
+++ b/src/main/resources/queries/video-daily-reliability.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Widget_Events.VideoDailyReliability]

--- a/src/main/resources/queries/video-folder-rls-stats.sql
+++ b/src/main/resources/queries/video-folder-rls-stats.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Widget_Events.VideoFolderRLSStats`

--- a/src/main/resources/queries/video-non-rls-stats.sql
+++ b/src/main/resources/queries/video-non-rls-stats.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Widget_Events.VideoNonRLSStats`

--- a/src/main/resources/queries/video-rls-stats.sql
+++ b/src/main/resources/queries/video-rls-stats.sql
@@ -1,3 +1,2 @@
 #standardSQL
-
 SELECT * FROM `client-side-events.Widget_Events.VideoRLSStats`

--- a/src/main/resources/queries/video-widget-usage-by-month.sql
+++ b/src/main/resources/queries/video-widget-usage-by-month.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Widget_Events.VideoUsageMonthly]

--- a/src/main/resources/queries/viewer-daily-reliability.sql
+++ b/src/main/resources/queries/viewer-daily-reliability.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Installer_Events.ViewerDailyReliability]

--- a/src/main/resources/queries/viewer-display-crash.sql
+++ b/src/main/resources/queries/viewer-display-crash.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Viewer_Events.DisplaysWithRestartsDueToViewerCrash]

--- a/src/main/resources/queries/viewer-exception-details.sql
+++ b/src/main/resources/queries/viewer-exception-details.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Viewer_Events.ExceptionDetails]

--- a/src/main/resources/queries/viewer-exception-summary.sql
+++ b/src/main/resources/queries/viewer-exception-summary.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Viewer_Events.ExceptionSummary]

--- a/src/main/resources/queries/viewer-launch-reliability.sql
+++ b/src/main/resources/queries/viewer-launch-reliability.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Installer_Events.DisplaysNotLaunchingViewer]

--- a/src/main/resources/queries/webpage-widget-usage-by-month.sql
+++ b/src/main/resources/queries/webpage-widget-usage-by-month.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Widget_Events.WebpageUsageMonthly]

--- a/src/main/resources/queries/widget-ready-reliability.sql
+++ b/src/main/resources/queries/widget-ready-reliability.sql
@@ -1,1 +1,2 @@
+#legacySql
 SELECT * FROM [client-side-events:Installer_Events.WidgetReadyReliability]


### PR DESCRIPTION
Revised queries to explicitly declare legacy SQL dialect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized SQL query formatting and dialect markers across multiple query files.
  * Normalized whitespace formatting in SQL files for consistency.

* **Chores**
  * Updated several queries to use standardized SQL syntax.
  * Removed deprecated or unused query files from the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->